### PR TITLE
Remove Gem Versions and Install Necessary Dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,52 +1,63 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # A DSL for quickly creating web applications
 # https://github.com/sinatra/sinatra
-gem "sinatra", "~> 2.1"
+gem 'sinatra', '~> 2.1'
 
 # An object-relational mapper
 # https://guides.rubyonrails.org/active_record_basics.html
-gem "activerecord", "~> 6.1"
+gem 'activerecord', '~> 6.1'
 
 # Configures common Rake tasks for working with Active Record
 # https://github.com/sinatra-activerecord/sinatra-activerecord
-gem "sinatra-activerecord"
-
-# Rack middleware. Used specifically for parsing the request body into params.
-# https://github.com/rack/rack-contrib
-gem "rack-contrib", "~> 2.3"
+gem 'sinatra-activerecord'
 
 # Run common tasks from the command line
 # https://github.com/ruby/rake
-gem "rake"
+gem 'rake'
 
 # Provides functionality to interact with a SQLite3 database
 # https://github.com/sparklemotion/sqlite3-ruby
-gem "sqlite3", "~> 1.4"
+gem 'sqlite3', '~> 1.4'
 
 # Require all files in a folder
 # https://github.com/jarmo/require_all
-gem "require_all"
+gem 'require_all'
+
+# Logger for Ruby 3.3+ compatibility
+gem 'logger'
+
+# Additional Ruby 3.3+ compatibility gems
+gem 'base64'
+gem 'bigdecimal'
+gem 'mutex_m'
+gem 'ostruct'
+
+# JSON body parser for Rack
+gem 'rack-contrib'
+
+# Web servers
+gem 'puma'
+gem 'webrick'
 
 # These gems will only be used when we are running the application locally
 group :development do
   # Used to generate seed data
   # https://github.com/faker-ruby/faker
-  gem "faker", "~> 2.18"
+  gem 'faker', '~> 2.18'
 
   # Auto-reload the server when files are changed
   # https://github.com/alexch/rerun
-  gem "rerun"
+  gem 'rerun'
 
-  gem "pry"
+  gem 'pry'
 end
 
 # These gems will only be used when we are running tests
 group :test do
-  gem "database_cleaner"
-  gem "rspec"
-  gem "rack-test", "~> 1.1"
-  gem "rspec-json_expectations", "~> 2.2"
+  gem 'database_cleaner'
+  gem 'rack-test', '~> 1.1'
+  gem 'rspec'
+  gem 'rspec-json_expectations'
+  gem 'rubocop'
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,102 +1,176 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activerecord (6.1.4)
-      activemodel (= 6.1.4)
-      activesupport (= 6.1.4)
-    activesupport (6.1.4)
+    activemodel (6.1.7.10)
+      activesupport (= 6.1.7.10)
+    activerecord (6.1.7.10)
+      activemodel (= 6.1.7.10)
+      activesupport (= 6.1.7.10)
+    activesupport (6.1.7.10)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (3.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
+    concurrent-ruby (1.3.5)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
+      database_cleaner-core (~> 2.0)
     database_cleaner-core (2.0.1)
-    diff-lcs (1.4.4)
-    faker (2.18.0)
-      i18n (>= 1.6, < 2)
-    ffi (1.15.3)
-    i18n (1.8.10)
+    diff-lcs (1.6.2)
+    faker (2.23.0)
+      i18n (>= 1.8.11, < 2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    listen (3.5.1)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    method_source (1.0.0)
-    minitest (5.14.4)
-    mustermann (1.1.1)
+    logger (1.7.0)
+    method_source (1.1.0)
+    minitest (5.25.5)
+    mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
-    pry (0.14.1)
+    mutex_m (0.3.0)
+    nio4r (2.7.4)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.3)
-    rack-contrib (2.3.0)
-      rack (~> 2.0)
-    rack-protection (2.1.0)
+    puma (6.6.1)
+      nio4r (~> 2.0)
+    racc (1.8.1)
+    rack (2.2.17)
+    rack-contrib (2.5.0)
+      rack (< 4)
+    rack-protection (2.2.4)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rake (13.0.6)
-    rb-fsevent (0.11.0)
-    rb-inotify (0.10.1)
+    rainbow (3.1.1)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
+    regexp_parser (2.11.0)
     require_all (3.0.0)
-    rerun (0.13.1)
+    rerun (0.14.0)
       listen (~> 3.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
+      rspec-support (~> 3.13.0)
     rspec-json_expectations (2.2.0)
-    rspec-mocks (3.10.2)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
+    rubocop (1.79.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
+    sinatra (2.2.4)
+      mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.1.0)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
-    sinatra-activerecord (2.0.23)
+    sinatra-activerecord (2.0.28)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
-    sqlite3 (1.4.2)
-    tilt (2.0.10)
-    tzinfo (2.0.4)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    tilt (2.6.1)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.4.2)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
+    webrick (1.9.1)
+    zeitwerk (2.7.3)
 
 PLATFORMS
-  universal-darwin-20
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   activerecord (~> 6.1)
+  base64
+  bigdecimal
   database_cleaner
   faker (~> 2.18)
+  logger
+  mutex_m
+  ostruct
   pry
-  rack-contrib (~> 2.3)
+  puma
+  rack-contrib
   rack-test (~> 1.1)
   rake
   require_all
   rerun
   rspec
-  rspec-json_expectations (~> 2.2)
+  rspec-json_expectations
+  rubocop
   sinatra (~> 2.1)
   sinatra-activerecord
   sqlite3 (~> 1.4)
+  webrick
 
 BUNDLED WITH
-   2.2.23
+   2.7.1

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
-require_relative './config/environment'
+require_relative 'config/environment'
+require 'rack/contrib'
 
 # Parse JSON from the request body into the params hash
 use Rack::JSONBodyParser

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,10 +1,13 @@
 # This is an _environment variable_ that is used by some of the Rake tasks to determine
 # if our application is running locally in development, in a test environment, or in production
-ENV['RACK_ENV'] ||= "development"
+ENV['RACK_ENV'] ||= 'development'
+
+# Require logger first for Ruby 3.3+ compatibility
+require 'logger'
 
 # Require in Gems
 require 'bundler/setup'
-Bundler.require(:default, ENV['RACK_ENV'])
+Bundler.require(:default, ENV.fetch('RACK_ENV', nil))
 
 # Require in all files in 'app' directory
 require_all 'app'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,12 @@
 ENV['RACK_ENV'] = 'test'
-require_relative "../config/environment"
-require "sinatra/activerecord/rake"
+require_relative '../config/environment'
+require 'sinatra/activerecord/rake'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
 
-  # Database setup
-  if ActiveRecord::Base.connection.migration_context.needs_migration?
-    # Run migrations for test environment
-    Rake::Task["db:migrate"].execute
-  end
-
   config.before(:suite) do
+    Rake::Task['db:migrate'].execute
     DatabaseCleaner.clean_with(:truncation)
   end
 
@@ -38,7 +33,7 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
-  
+
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
 


### PR DESCRIPTION
This pull request updates dependencies and improves compatibility with Ruby 3.3+ while cleaning up and standardizing the codebase. The key changes include updates to the `Gemfile`, configuration files, and test setup to ensure compatibility and consistency.

### Dependency Updates and Compatibility Improvements:

* Updated `Gemfile` to use single quotes for consistency, added Ruby 3.3+ compatibility gems (`logger`, `base64`, `bigdecimal`, `mutex_m`, `ostruct`), and included additional gems like `puma` and `webrick` for web server support. Also, moved `rack-contrib` to the correct position and added `rubocop` for test environment linting.

* Added `require 'logger'` in `config/environment.rb` to ensure compatibility with Ruby 3.3+ and updated `Bundler.require` to use `ENV.fetch` for safer environment variable handling.

### Configuration and Test Setup:

* Updated `config.ru` to include `require 'rack/contrib'` and added `use Rack::JSONBodyParser` middleware to enable JSON body parsing.

* Simplified `spec/spec_helper.rb` by removing redundant migration checks and ensuring database migrations are executed before tests using `Rake::Task['db:migrate'].execute`.